### PR TITLE
Add confirmation dialog for deleting sessions

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -21,6 +21,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import * as prompts from './prompts'
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import CleanWidnow from './CleanWindow';
+import DeleteSessionDialog from './DeleteSessionDialog';
 import { ThemeSwitcherProvider } from './theme/ThemeSwitcher';
 
 const { useEffect, useState } = React
@@ -90,6 +91,8 @@ function Main() {
 
     const [sessionClean, setSessionClean] = React.useState<Session | null>(null);
 
+    const [sessionToDelete, setSessionToDelete] = React.useState<Session | null>(null);
+
     const generateName = async (session: Session) => {
         client.replay(
             store.settings.openaiKey,
@@ -105,6 +108,10 @@ function Main() {
             }
         )
     }
+
+    const handleDeleteSession = (session: Session) => {
+        setSessionToDelete(session);
+    };
 
     const generate = async (session: Session, promptMsgs: Message[], targetMsg: Message) => {
         await client.replay(
@@ -200,7 +207,7 @@ function Main() {
                                             store.switchCurrentSession(session)
                                             document.getElementById('message-input')?.focus() // better way?
                                         }}
-                                        deleteMe={() => store.deleteChatSession(session)}
+                                        deleteMe={() => handleDeleteSession(session)}
                                         copyMe={() => {
                                             const newSession = createSession(session.name + ' Copyed')
                                             newSession.messages = session.messages
@@ -386,6 +393,19 @@ function Main() {
                                 setSessionClean(null)
                             }}
                             close={() => setSessionClean(null)}
+                        />
+                    )
+                }
+                {
+                    sessionToDelete !== null && (
+                        <DeleteSessionDialog 
+                            open={sessionToDelete !== null}
+                            session={sessionToDelete}
+                            onConfirm={() => {
+                                store.deleteChatSession(sessionToDelete);
+                                setSessionToDelete(null);
+                            }}
+                            onCancel={() => setSessionToDelete(null)}
                         />
                     )
                 }

--- a/src/devtools/DeleteSessionDialog.tsx
+++ b/src/devtools/DeleteSessionDialog.tsx
@@ -1,0 +1,33 @@
+import './App.css';
+import {
+    Button, Dialog, DialogContent, DialogActions, DialogTitle, DialogContentText,
+} from '@mui/material';
+import { Session } from './types'
+
+interface Props {
+    open: boolean
+    session: Session | null
+    onConfirm: () => void
+    onCancel: () => void
+}
+
+export default function DeleteSessionDialog(props: Props) {
+    const handleDelete = () => {
+        props.onConfirm()
+    }
+    
+    return (
+        <Dialog open={props.open} onClose={props.onCancel}>
+            <DialogTitle>Delete Session</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Are you sure you want to delete '{props.session?.name}'? This action cannot be undone.
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={props.onCancel}>Cancel</Button>
+                <Button onClick={handleDelete} color="error">Delete</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}


### PR DESCRIPTION
**Description:** This pull request adds a feature that displays a deletion confirmation dialog when a user attempts to delete a chat session. Upon clicking the three buttons on a chat session and selecting delete, users are prompted to either cancel the deletion process or to confirm the deletion. Upon confirmation, the chat session is permanently deleted. This fixes issue #12. 

**Before**
<img width="1396" height="823" alt="Screenshot 2025-10-19 at 2 45 09 PM" src="https://github.com/user-attachments/assets/cb957e90-9e26-43ab-a61a-45a1eeb4f4e3" />
<img width="1396" height="823" alt="Screenshot 2025-10-19 at 2 45 18 PM" src="https://github.com/user-attachments/assets/bbdaac89-6db2-4e51-a062-29b8df2559ca" />

**After**
<img width="1396" height="823" alt="Screenshot 2025-10-19 at 2 46 03 PM" src="https://github.com/user-attachments/assets/9f3b7568-d10d-4292-916b-f8c7eefdc063" />

[Issue Demo Video](https://youtu.be/E3tqOub_H3o)