### PR TITLE
add character count for messages

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -431,8 +431,8 @@ function MessageInput(props: {
     }
     return (
         <form onSubmit={submit}>
-            <Stack direction="column" spacing={1}>
-                <Stack direction="row" spacing={1} alignItems="center">
+            <Stack direction="row" spacing={1} alignItems="center">
+                <Stack direction="column" spacing={1} sx={{ flexGrow: 1 }}>
                     <TextField
                         multiline
                         label="Prompt"
@@ -450,11 +450,18 @@ function MessageInput(props: {
                             }
                         }}
                     />
-                    <Button type='submit' variant="contained" size='large'>
-                        SEND
-                    </Button>
+                    <Stack direction="row" justifyContent="space-between">
+                        <Typography variant='caption' style={{ opacity: 0.3 }}>
+                            [Enter] send, [Shift+Enter] line break
+                        </Typography>
+                        <Typography variant='caption' style={{ opacity: 0.3 }}>
+                            {messageInput.length} characters
+                        </Typography>
+                    </Stack>
                 </Stack>
-                <Typography variant='caption' style={{ opacity: 0.3 }}>[Enter] send, [Shift+Enter] line break</Typography>
+                <Button type='submit' variant="contained" size='large'>
+                    SEND
+                </Button>
             </Stack>
         </form>
     )


### PR DESCRIPTION
Description: This feature allows users to see a live-updating character count as they type out their prompt. This character count resets to zero when the prompt is sent and is a subtle addition to the text right below the prompt box. This addresses issue #24. 

Before:
<img width="655" height="390" alt="Screenshot 2025-11-16 at 9 01 39 PM" src="https://github.com/user-attachments/assets/ab1883df-16dd-409b-a03a-c5c8cd1198be" />

After:
<img width="1395" height="795" alt="Screenshot 2025-11-16 at 8 45 46 PM" src="https://github.com/user-attachments/assets/9e0992e2-73d0-43dd-9ccc-85003cf22bf2" />

[Video](https://youtu.be/UiGlpXpqAt8)
 