### PR TITLE
feat: add pin functionality for chat sessions

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -90,6 +90,8 @@ function Main() {
 
     const [sessionClean, setSessionClean] = React.useState<Session | null>(null);
 
+    const [toastMessage, setToastMessage] = React.useState<string | null>(null);
+
     const generateName = async (session: Session) => {
         client.replay(
             store.settings.openaiKey,
@@ -193,22 +195,64 @@ function Main() {
                             }
                         >
                             {
-                                store.chatSessions.map((session, ix) => (
-                                    <SessionItem selected={store.currentSession.id === session.id}
-                                        session={session}
-                                        switchMe={() => {
-                                            store.switchCurrentSession(session)
-                                            document.getElementById('message-input')?.focus() // better way?
-                                        }}
-                                        deleteMe={() => store.deleteChatSession(session)}
-                                        copyMe={() => {
-                                            const newSession = createSession(session.name + ' Copyed')
-                                            newSession.messages = session.messages
-                                            store.createChatSession(newSession, ix)
-                                        }}
-                                        editMe={() => setConfigureChatConfig(session)}
-                                    />
-                                ))
+                                (() => {
+                                    const pinnedSessions = store.chatSessions.filter(s => s.pinned)
+                                    const unpinnedSessions = store.chatSessions.filter(s => !s.pinned)
+
+                                    return (
+                                        <>
+                                            {pinnedSessions.map((session, ix) => (
+                                                <SessionItem selected={store.currentSession.id === session.id}
+                                                    session={session}
+                                                    switchMe={() => {
+                                                        store.switchCurrentSession(session)
+                                                        document.getElementById('message-input')?.focus() // better way?
+                                                    }}
+                                                    deleteMe={() => store.deleteChatSession(session)}
+                                                    copyMe={() => {
+                                                        const newSession = createSession(session.name + ' Copyed')
+                                                        newSession.messages = session.messages
+                                                        store.createChatSession(newSession, ix)
+                                                    }}
+                                                    editMe={() => setConfigureChatConfig(session)}
+                                                    togglePin={() => {
+                                                        const result = store.togglePinSession(session)
+                                                        if (!result.success) {
+                                                            setToastMessage(result.message)
+                                                        }
+                                                    }}
+                                                />
+                                            ))}
+
+                                            {pinnedSessions.length > 0 && unpinnedSessions.length > 0 && (
+                                                <Divider sx={{ my: 1 }} />
+                                            )}
+
+                                            {unpinnedSessions.map((session, ix) => (
+                                                <SessionItem selected={store.currentSession.id === session.id}
+                                                    session={session}
+                                                    switchMe={() => {
+                                                        store.switchCurrentSession(session)
+                                                        document.getElementById('message-input')?.focus() // better way?
+                                                    }}
+                                                    deleteMe={() => store.deleteChatSession(session)}
+                                                    copyMe={() => {
+                                                        const newSession = createSession(session.name + ' Copyed')
+                                                        newSession.messages = session.messages
+                                                        store.createChatSession(newSession, ix)
+                                                    }}
+                                                    editMe={() => setConfigureChatConfig(session)}
+                                                    togglePin={() => {
+                                                        const result = store.togglePinSession(session)
+                                                        if (!result.success) {
+                                                            setToastMessage(result.message)
+                                                        }
+                                                    }}
+                                                />
+                                            ))}
+                                        </>
+                                    )
+                                })()
                             }
                         </MenuList>
 
@@ -399,6 +443,13 @@ function Main() {
                         />
                     ))
                 }
+                <Snackbar
+                    open={toastMessage !== null}
+                    autoHideDuration={3000}
+                    onClose={() => setToastMessage(null)}
+                    message={toastMessage}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+                />
             </Grid>
         </Box >
     );

--- a/src/devtools/SessionItem.tsx
+++ b/src/devtools/SessionItem.tsx
@@ -13,6 +13,8 @@ import CloseIcon from '@mui/icons-material/Close';
 import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import MoreHorizOutlinedIcon from '@mui/icons-material/MoreHorizOutlined';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import StyledMenu from './StyledMenu';
 
 const { useState } = React
@@ -24,10 +26,11 @@ export interface Props {
     deleteMe: () => void
     copyMe: () => void
     editMe: () => void
+    togglePin: () => void
 }
 
 export default function SessionItem(props: Props) {
-    const { session, selected, switchMe, deleteMe, copyMe, editMe } = props
+    const { session, selected, switchMe, deleteMe, copyMe, editMe, togglePin } = props
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -52,6 +55,18 @@ export default function SessionItem(props: Props) {
                     {session.name}
                 </Typography>
             </ListItemText>
+            <IconButton
+                onClick={(e) => {
+                    e.stopPropagation();
+                    togglePin();
+                }}
+                size="small"
+            >
+                {session.pinned ?
+                    <PushPinIcon fontSize="small" color="primary" /> :
+                    <PushPinOutlinedIcon fontSize="small" />
+                }
+            </IconButton>
             <IconButton onClick={handleClick}>
                 <MoreHorizOutlinedIcon />
             </IconButton>

--- a/src/devtools/store.ts
+++ b/src/devtools/store.ts
@@ -76,7 +76,8 @@ export async function readSessions(): Promise<Session[]> {
     if (sessions.length === 0) {
         return [createSession()]
     }
-    return sessions
+    // Ensure all sessions have pinned property for backward compatibility
+    return sessions.map((s: Session) => ({ ...s, pinned: s.pinned ?? false }))
 }
 
 export async function writeSessions(sessions: Session[]) {
@@ -152,6 +153,21 @@ export default function useStore() {
         createChatSession(createSession())
     }
 
+    const togglePinSession = (session: Session) => {
+        const pinnedCount = chatSessions.filter(s => s.pinned).length
+
+        // Check if trying to pin when already at limit
+        if (!session.pinned && pinnedCount >= 3) {
+            return { success: false, message: "Maximum 3 chats can be pinned" }
+        }
+
+        // Toggle pin status
+        const updatedSession = { ...session, pinned: !session.pinned }
+        updateChatSession(updatedSession)
+
+        return { success: true }
+    }
+
     const setMessages = (session: Session, messages: Message[]) => {
         updateChatSession({
             ...session,
@@ -180,6 +196,7 @@ export default function useStore() {
         updateChatSession,
         deleteChatSession,
         createEmptyChatSession,
+        togglePinSession,
 
         currentSession,
         switchCurrentSession,

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -10,6 +10,7 @@ export interface Session{
     id: string
     name: string
     messages: Message[]
+    pinned?: boolean
 }
 
 export function createMessage(role: ChatCompletionRequestMessageRoleEnum = ChatCompletionRequestMessageRoleEnum.User, content: string = ''): Message {
@@ -25,6 +26,7 @@ export function createSession(name: string = "Untitled"): Session {
         id: uuidv4(),
         name: name,
         messages: [],
+        pinned: false,
     }
 }
 


### PR DESCRIPTION
Description: Allow users to pin up to 3 chat sessions to keep important conversations at the top of the session list for quick
access. This fixes issue #29. 

Before: 
<img width="1397" height="828" alt="Screenshot 2025-11-23 at 10 55 24 PM" src="https://github.com/user-attachments/assets/488e6cb9-4020-4a85-9f9e-dfed23b1dfe3" />

After: 
<img width="1397" height="828" alt="Screenshot 2025-11-23 at 10 43 36 PM" src="https://github.com/user-attachments/assets/d0a4d44b-fae0-4c67-b72d-111deb93a208" />

[Video](https://youtu.be/NKqbWFTJqRk)