### PR TITLE
add tooltips to icon buttons

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -7,7 +7,7 @@ import {
     Toolbar, Box, Badge, Snackbar,
     List, ListSubheader, ListItemText, MenuList,
     IconButton, Button, Stack, Grid, MenuItem, ListItemIcon, Typography, Divider,
-    TextField,
+    TextField, Tooltip,
 } from '@mui/material';
 import { Session, createSession, Message, createMessage } from './types'
 import ChatIcon from '@mui/icons-material/Chat';
@@ -165,9 +165,11 @@ function Main() {
                         spacing={2}
                     >
                         <Toolbar variant="dense">
-                            <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
-                                <ChatIcon />
-                            </IconButton>
+                            <Tooltip title="ChatBox">
+                                <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+                                    <ChatIcon />
+                                </IconButton>
+                            </Tooltip>
                             <Typography variant="h5" color="inherit" component="div">
                                 ChatBox
                             </Typography>
@@ -216,7 +218,9 @@ function Main() {
 
                         <MenuItem onClick={() => store.createEmptyChatSession()} >
                             <ListItemIcon>
-                                <IconButton><AddIcon fontSize="small" /></IconButton>
+                                <Tooltip title="Create new chat">
+                                    <IconButton><AddIcon fontSize="small" /></IconButton>
+                                </Tooltip>
                             </ListItemIcon>
                             <ListItemText>
                                 New Chat
@@ -230,7 +234,9 @@ function Main() {
                         }}
                         >
                             <ListItemIcon>
-                                <IconButton><SettingsIcon fontSize="small" /></IconButton>
+                                <Tooltip title="Open settings">
+                                    <IconButton><SettingsIcon fontSize="small" /></IconButton>
+                                </Tooltip>
                             </ListItemIcon>
                             <ListItemText>
                                 Settings
@@ -245,9 +251,11 @@ function Main() {
                             openLink('https://github.com/Bin-Huang/chatbox/releases')
                         }}>
                             <ListItemIcon>
-                                <IconButton>
-                                    <InfoOutlinedIcon fontSize="small" />
-                                </IconButton>
+                                <Tooltip title="Check for updates">
+                                    <IconButton>
+                                        <InfoOutlinedIcon fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
                             </ListItemIcon>
                             <ListItemText>
                                 <Badge color="primary" variant="dot" invisible={!needCheckUpdate} sx={{ paddingRight: '8px' }} >
@@ -270,17 +278,21 @@ function Main() {
                         padding: '20px 0',
                     }} spacing={2}>
                         <Toolbar variant="dense">
-                            <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
-                                <ChatBubbleOutlineOutlinedIcon />
-                            </IconButton>
+                            <Tooltip title="Current conversation">
+                                <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}>
+                                    <ChatBubbleOutlineOutlinedIcon />
+                                </IconButton>
+                            </Tooltip>
                             <Typography variant="h6" color="inherit" component="div" noWrap sx={{ flexGrow: 1 }}>
                                 {store.currentSession.name}
                             </Typography>
-                            <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}
-                                onClick={() => setSessionClean(store.currentSession)}
-                            >
-                                <CleaningServicesIcon />
-                            </IconButton>
+                            <Tooltip title="Clear all messages">
+                                <IconButton edge="start" color="inherit" aria-label="menu" sx={{ mr: 2 }}
+                                    onClick={() => setSessionClean(store.currentSession)}
+                                >
+                                    <CleaningServicesIcon />
+                                </IconButton>
+                            </Tooltip>
                         </Toolbar>
                         <Divider />
                         <List

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -3,7 +3,7 @@ import { ChatCompletionRequestMessage, ChatCompletionRequestMessageRoleEnum } fr
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
 import MenuItem from '@mui/material/MenuItem';
-import { Button, Divider, ListItem, Typography, Grid, TextField, Menu, MenuProps } from '@mui/material';
+import { Button, Divider, ListItem, Typography, Grid, TextField, Menu, MenuProps, Tooltip } from '@mui/material';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import PersonIcon from '@mui/icons-material/Person';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
@@ -169,19 +169,25 @@ function _Block(props: Props) {
                         {
                             isEditing ? (
                                 <>
-                                <Button onClick={() => setIsEditing(false)}>
-                                    <CheckIcon fontSize='small' />
-                                </Button>
+                                <Tooltip title="Save changes">
+                                    <Button onClick={() => setIsEditing(false)}>
+                                        <CheckIcon fontSize='small' />
+                                    </Button>
+                                </Tooltip>
                                 </>
                             ) : (
                                 isHovering && (
                                     <>
-                                        <Button onClick={() => props.refreshMsg()}>
-                                            <RefreshIcon fontSize='small' />
-                                        </Button>
-                                        <Button onClick={handleClick}>
-                                            <MoreVertIcon />
-                                        </Button>
+                                        <Tooltip title="Regenerate response">
+                                            <Button onClick={() => props.refreshMsg()}>
+                                                <RefreshIcon fontSize='small' />
+                                            </Button>
+                                        </Tooltip>
+                                        <Tooltip title="More actions">
+                                            <Button onClick={handleClick}>
+                                                <MoreVertIcon />
+                                            </Button>
+                                        </Tooltip>
                                         <StyledMenu
                                             MenuListProps={{
                                                 'aria-labelledby': 'demo-customized-button',

--- a/src/devtools/SessionItem.tsx
+++ b/src/devtools/SessionItem.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import './App.css';
 import {
     ListItemText, ListItemAvatar, MenuItem, Divider,
-    Avatar, IconButton, Button, TextField, Popper, Fade, Typography, ListItemIcon,
+    Avatar, IconButton, Button, TextField, Popper, Fade, Typography, ListItemIcon, Tooltip,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Session } from './types'
@@ -45,16 +45,20 @@ export default function SessionItem(props: Props) {
             onClick={() => switchMe()}
         >
             <ListItemIcon>
-                <IconButton><ChatBubbleOutlineOutlinedIcon fontSize="small" /></IconButton>
+                <Tooltip title="Chat session">
+                    <IconButton><ChatBubbleOutlineOutlinedIcon fontSize="small" /></IconButton>
+                </Tooltip>
             </ListItemIcon>
             <ListItemText>
                 <Typography variant="inherit" noWrap>
                     {session.name}
                 </Typography>
             </ListItemText>
-            <IconButton onClick={handleClick}>
-                <MoreHorizOutlinedIcon />
-            </IconButton>
+            <Tooltip title="Session options">
+                <IconButton onClick={handleClick}>
+                    <MoreHorizOutlinedIcon />
+                </IconButton>
+            </Tooltip>
             <StyledMenu
                 MenuListProps={{
                     'aria-labelledby': 'long-button',


### PR DESCRIPTION
Description: Use material-UI tool tips to add context/tips to icons in chatbox. Fixes issue #30 . 
Before:
<img width="638" height="389" alt="Screenshot 2025-12-07 at 11 49 53 PM" src="https://github.com/user-attachments/assets/3d565a32-32bb-44ee-abdd-e2d8ccc577dd" />

After:
<img width="846" height="729" alt="Screenshot 2025-12-07 at 11 35 27 PM" src="https://github.com/user-attachments/assets/36e4f39d-0d4b-413c-aa3b-b5a15bcb548e" />

[Video](https://youtu.be/maAGdL4YMQg)